### PR TITLE
Make base path configurable

### DIFF
--- a/EdgarClient.py
+++ b/EdgarClient.py
@@ -9,6 +9,11 @@ from edgar.xbrl import *
 import pandas as pd
 from typing import Optional
 import numpy as np
+import os
+
+# Default directory for reading/writing data. Can be overridden by
+# the SEC_FUNDAMENTALS_DIR environment variable.
+BASE_DIR = os.environ.get('SEC_FUNDAMENTALS_DIR', r'D:\code\SEC_Fundamentals')
 
 def get_income_statement_edgartools(ticker, form_type="10-Q"):
     """
@@ -400,16 +405,16 @@ def testRun(ticker):
     return ratios,data
     
 
-def ReadSPXItems():
-    
-    path = "D:\\code\\SEC_Fundamentals\\allTickers.csv"
+def ReadSPXItems(base_dir: str | None = None):
+
+    base_dir = base_dir or BASE_DIR
+    path = os.path.join(base_dir, "allTickers.csv")
     df_ticker = pd.read_csv(path)
     return df_ticker
 
 
 if __name__=="__main__":
-    
-    ticker = ReadSPXItems() 
-    r,d = testRun(ticker["ticker"].iloc[:10])
+
+    ticker = ReadSPXItems(BASE_DIR)
+    r, d = testRun(ticker["ticker"].iloc[:10])
         
-  

--- a/GetData.py
+++ b/GetData.py
@@ -24,6 +24,10 @@ from typing import Optional
 import numpy as np
 import os
 
+# Base directory for saved data. Can be overridden with the
+# SEC_FUNDAMENTALS_DIR environment variable.
+BASE_DIR = os.environ.get('SEC_FUNDAMENTALS_DIR', r'D:\code\SEC_Fundamentals')
+
 def saveAccountingData(df_dict,path):
     
     output_dir = f"{path}"
@@ -53,11 +57,12 @@ def GetAccountingDict(filings):
     return data
 
 
-def GetAccountingData(ticker:str,howFarBack):
-    
+def GetAccountingData(ticker: str, howFarBack, base_dir: Optional[str] = None):
+
     c = Company(ticker)
-    base_path = f"D:\\code\\SEC_Fundamentals\\{ticker}\\"
-    
+    base_dir = base_dir or BASE_DIR
+    base_path = os.path.join(base_dir, ticker)
+
     Time_Frame = howFarBack
     
     
@@ -74,9 +79,10 @@ def GetAccountingData(ticker:str,howFarBack):
     
 
 
-def GetAllTickers():
-    
-    path = "D:\\code\\SEC_Fundamentals\\allTickers.csv"
+def GetAllTickers(base_dir: Optional[str] = None):
+
+    base_dir = base_dir or BASE_DIR
+    path = os.path.join(base_dir, "allTickers.csv")
     df_ticker = pd.read_csv(path)
     return df_ticker
 
@@ -84,10 +90,11 @@ def main():
     
     email = "magnus@pagnus.com"
     set_identity(email)
-    tickers = GetAllTickers()
+    base_dir = BASE_DIR
+    tickers = GetAllTickers(base_dir)
     tickers = tickers["ticker"].iloc[:150]
     for ticker in tickers:
-        GetAccountingData(ticker,15)
+        GetAccountingData(ticker, 15, base_dir)
 
 if __name__ == "__main__":
     main()

--- a/OrderDataFrame.py
+++ b/OrderDataFrame.py
@@ -3,8 +3,11 @@ import pandas as pd
 from collections import Counter
 import matplotlib.pyplot as plt
 
-def GetDataFromFiles():
-        base_path = r"D:\code\SEC_Fundamentals"
+# Base directory for CSV files. Override with SEC_FUNDAMENTALS_DIR
+BASE_DIR = os.environ.get('SEC_FUNDAMENTALS_DIR', r'D:\code\SEC_Fundamentals')
+
+def GetDataFromFiles(base_path: str | None = None):
+        base_path = base_path or BASE_DIR
         tickers = [name for name in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, name))]
     
         # Dictionary: {ticker: {'balanceSheet': df, ...}}
@@ -462,29 +465,25 @@ def accounting_checks(df_income):
     print(f"Rows with Net Income mismatch: {mismatch_net.sum()}")
 
 
+
 if __name__=="__main__":
-    
-    data,col_freq = GetDataFromFiles()
-    base_path = r"D:\code\SEC_Fundamentals"
+
+    data, col_freq = GetDataFromFiles(BASE_DIR)
+    base_path = BASE_DIR
     IS = col_freq[0]
 
-   
     mappings = {
         'income': IS_Hard_Mapping(),
         'balance': BS_Hard_Mapping(),
         'cashflow': CS_Hard_Mapping() }
-    
+
     aggregator = SECDataAggregator(base_path, mappings)
     df_income = aggregator.load_and_standardize('income')
     df_balance = aggregator.load_and_standardize("balance")
     df_cash = aggregator.load_and_standardize("cashflow")
-    
-    
-    path = "D:\\code\\SEC_Fundamentals\\summary_statement\\"
-    #==================== PRINT THE DATA FRAMES TO CSV FILES =========================#
-    df_income.to_csv(path+"income_statement.csv")
-    df_balance.to_csv(path+"balance_sheet.csv")
-    df_cash.to_csv(path+"cashflow_statement.csv")
-    
 
-    
+    path = os.path.join(base_path, "summary_statement")
+    #==================== PRINT THE DATA FRAMES TO CSV FILES =====================#
+    df_income.to_csv(os.path.join(path, "income_statement.csv"))
+    df_balance.to_csv(os.path.join(path, "balance_sheet.csv"))
+    df_cash.to_csv(os.path.join(path, "cashflow_statement.csv"))

--- a/TestSEC.py
+++ b/TestSEC.py
@@ -5,13 +5,16 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from sec_edgar_downloader import Downloader
 
+# Directory where sample data lives. Configurable via SEC_FUNDAMENTALS_DIR.
+BASE_DIR = os.environ.get("SEC_FUNDAMENTALS_DIR", r"D:\code\SEC_Fundamentals")
+
 # Install requirements:
 # pip install sec-edgar-downloader beautifulsoup4 lxml pandas python-xbrl
 
 # Configure your SEC-compliant User-Agent info here:
 COMPANY_NAME = "Your Company or App Name"
 EMAIL_ADDRESS = "your.email@domain.com"
-addl = "D:\\code\\SEC_Fundamentals\\" # Not a good solution. fix it...
+addl = os.path.join(BASE_DIR, "")  # Not a good solution. fix it...
 
 
 def download_10q_filings(ticker, num_filings=4, download_dir="edgar_data"):


### PR DESCRIPTION
## Summary
- remove hard-coded SEC_Fundamentals paths
- allow base directory to be set via `SEC_FUNDAMENTALS_DIR`
- clean up stray Windows line endings

## Testing
- `python3 -m py_compile GetData.py OrderDataFrame.py EdgarClient.py TestSEC.py`


------
https://chatgpt.com/codex/tasks/task_e_68604f1333308327b35c7b72dcd1ec29